### PR TITLE
added total row to tooltip

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -208,6 +208,9 @@ c3_chart_internal_fn.getDefaultConfig = function () {
         tooltip_init_position: {top: '0px', left: '50px'},
         tooltip_onshow: function () {},
         tooltip_onhide: function () {},
+        tooltip_total_show: false,
+        tooltip_total_name: undefined,
+        tooltip_total_format_value: undefined,
         // title
         title_text: undefined,
         title_padding: {

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -76,12 +76,15 @@ c3_chart_internal_fn.getTooltipContent = function (d, defaultTitleFormat, defaul
     // value will be formatted the same way as the other values
     if (config.tooltip_total_show) {
         totalValue = 0;
-        for (i=0; i < d.length; i++) {
+        for (i = 0; i < d.length; i++) {
+            if (! (d[i] && (d[i].value || d[i].value === 0))) { continue; }
             totalValue += d[i].value;
         }
         totalValue = totalValueFormat(totalValue);
-        text += "<tr><td class='name'><strong>" + totalName + "</strong></td>";
-        text += "<td class='value'>" + totalValue + "</td></tr>";
+        text += "<tr>";
+        text += "<td class='name'><strong>" + totalName + "</strong></td>";
+        text += "<td class='value'>" + totalValue + "</td>";
+        text += "</tr>";
     }
     return text + "</table>";
 };

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -29,7 +29,9 @@ c3_chart_internal_fn.getTooltipContent = function (d, defaultTitleFormat, defaul
         titleFormat = config.tooltip_format_title || defaultTitleFormat,
         nameFormat = config.tooltip_format_name || function (name) { return name; },
         valueFormat = config.tooltip_format_value || defaultValueFormat,
-        text, i, title, value, name, bgcolor,
+        totalName = config.tooltip_total_name || "Total",
+        totalValueFormat = config.tooltip_total_format_value || valueFormat,
+        text, i, title, value, name, bgcolor, totalValue,
         orderAsc = $$.isOrderAsc();
 
     if (config.data_groups.length === 0) {
@@ -69,6 +71,17 @@ c3_chart_internal_fn.getTooltipContent = function (d, defaultTitleFormat, defaul
             text += "<td class='value'>" + value + "</td>";
             text += "</tr>";
         }
+    }
+    // adding a "Total" row to the tooltip - if a formatter is not given then the total
+    // value will be formatted the same way as the other values
+    if (config.tooltip_total_show) {
+        totalValue = 0;
+        for (i=0; i < d.length; i++) {
+            totalValue += d[i].value;
+        }
+        totalValue = totalValueFormat(totalValue);
+        text += "<tr><td class='name'><strong>" + totalName + "</strong></td>";
+        text += "<td class='value'>" + totalValue + "</td></tr>";
     }
     return text + "</table>";
 };


### PR DESCRIPTION
Total row is added to the tooltip. When creating a graph, you can pass in the following options:

```javascript
c3.generate({
  tooltip: {
    total: {
      show: true,
      format: {
        value: function(totalValue) {
          // do something here...
          return totalValue + " dollars";
        }
      },
      name: 'My Total Row Name'
    }
  }
}
```

which would give:

![c3_test](https://cloud.githubusercontent.com/assets/5009136/11996954/5d0fce46-aa3d-11e5-9250-6fa1f6f0edfa.png)
